### PR TITLE
feat: add required field hints

### DIFF
--- a/src/components/CurrencyInput/CurrencyInput.vue
+++ b/src/components/CurrencyInput/CurrencyInput.vue
@@ -9,6 +9,8 @@
     :readonly="readonly"
     :disabled="disabled"
     :label="label"
+    :hint="hint"
+    :persistent-hint="persistentHint"
     @blur="onBlur()"
   />
 </template>
@@ -63,6 +65,14 @@ export default {
     label: {
       type: String,
       default: "",
+    },
+    hint: {
+      type: String,
+      default: null,
+    },
+    persistentHint: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props) {

--- a/src/components/subscription/bound/engineering/BoundClaims.vue
+++ b/src/components/subscription/bound/engineering/BoundClaims.vue
@@ -33,6 +33,8 @@
                   :options="currencyOptions"
                   @input="update(key, item.model)"
                   @blur="saveData(key, 'columnModel', item.model)"
+                  hint="Required field"
+                  persistent-hint
                 />
               </div>
               <div class="Row Large">

--- a/src/components/subscription/bound/engineering/InputsRisk.vue
+++ b/src/components/subscription/bound/engineering/InputsRisk.vue
@@ -50,6 +50,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('underwriter', 'boundEng')"
       ></v-select>
     </div>
 
@@ -65,6 +68,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('awAnalist1', 'boundEng')"
       ></v-select>
     </div>
     <div class="inputCont">

--- a/src/components/subscription/bound/engineering/PremiumPaymentWarranty.vue
+++ b/src/components/subscription/bound/engineering/PremiumPaymentWarranty.vue
@@ -23,6 +23,8 @@
             v-model="payment.installment"
             :label="'Installment ' + (index + 1) + '*'"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -38,6 +40,8 @@
             v-model="payment.percent"
             label="Percentage*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -55,6 +59,8 @@
                 label="PPW Due Date*"
                 v-bind="attrs"
                 v-on="on"
+                hint="Required field"
+                persistent-hint
               />
             </template>
             <v-date-picker
@@ -88,6 +94,8 @@
             item-value="id"
             item-text="clause"
             :items="clauseList"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -104,6 +112,8 @@
             v-model="payment.days_of_prior_notice"
             label="Days of prior notice*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
 

--- a/src/components/subscription/bound/engineering/Rational.vue
+++ b/src/components/subscription/bound/engineering/Rational.vue
@@ -20,13 +20,15 @@
         <div class="ExpandContent">
           <div class="TitleTextArea">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="$v.boundEng.rationalComments.$model"
             @blur="
               SET_BOUND_ENG('rationalComments', this);
               checkField('rationalComments');
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>

--- a/src/components/subscription/bound/engineering/RiskProfile.vue
+++ b/src/components/subscription/bound/engineering/RiskProfile.vue
@@ -20,13 +20,15 @@
         <div class="ExpandContent">
           <div class="TitleTextArea">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="$v.boundEng.riskProfileComments.$model"
             @blur="
               SET_BOUND_ENG('riskProfileComments', this);
               checkField('riskProfileComments');
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
 
           <div class="InputsCont d-flex justify-start align-center">
             <div class="InputCont">
@@ -42,6 +44,8 @@
                 item-value="id"
                 clearable
                 :disabled="typeClause.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
             <div class="InputCont">
@@ -57,6 +61,8 @@
                 item-value="id"
                 clearable
                 :disabled="exposure.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
             <div class="InputCont">
@@ -72,6 +78,8 @@
                 item-value="id"
                 clearable
                 :disabled="housekeeping.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
           </div>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/Claims.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/Claims.vue
@@ -34,6 +34,8 @@
                     :options="currencyOptions"
                     @blur="updateByColumn('amount', item.amount, item.sub)"
                     @input="$emit('bound-claims-change', boundClaimsCompleted)"
+                    hint="Required field"
+                    persistent-hint
                   />
                 </div>
                 <div class="input-row large">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/InputsRiskQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/InputsRiskQuotator.vue
@@ -33,6 +33,9 @@
         item-text="data"
         item-value="id"
         :disabled="disabled"
+        hint="Required field"
+        persistent-hint
+        :rules="[(v) => !!v || 'Required field']"
       ></v-select>
     </div>
     <div class="input-cont">
@@ -44,6 +47,9 @@
         item-text="data"
         item-value="id"
         :disabled="disabled"
+        hint="Required field"
+        persistent-hint
+        :rules="[(v) => !!v || 'Required field']"
       >
       </v-select>
     </div>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/MainLocation.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/MainLocation.vue
@@ -18,6 +18,8 @@
               v-model="mainLocation.damage"
               @blur="saveField('damage', mainLocation.damage)"
               :options="currencyOptions"
+              hint="Required field"
+              persistent-hint
             />
           </div>
           <div class="input-row">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/PmlProperty.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/PmlProperty.vue
@@ -22,6 +22,8 @@
               min="0"
               max="100"
               step="1"
+              hint="Required field"
+              persistent-hint
             />
           </div>
           <div class="input-row">
@@ -44,11 +46,13 @@
     </div>
 
     <div class="title-text-area">PML Comments*</div>
-    <textarea
+    <v-textarea
       v-model="pmlProperty.comments"
       @blur="saveField('comments', pmlProperty.comments)"
       @input="handleCommentsChange"
-    ></textarea>
+      hint="Required field"
+      persistent-hint
+    />
   </div>
 </template>
 <script>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/PremiumPaymentWarranty.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/PremiumPaymentWarranty.vue
@@ -23,6 +23,8 @@
             v-model="payment.installment"
             :label="'Installment ' + (index + 1) + '*'"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -38,6 +40,8 @@
             v-model="payment.percent"
             label="Percentage*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -55,6 +59,8 @@
                 label="PPW Due Date*"
                 v-bind="attrs"
                 v-on="on"
+                hint="Required field"
+                persistent-hint
               />
             </template>
             <v-date-picker
@@ -88,6 +94,8 @@
             item-value="id"
             item-text="clause"
             :items="clauseList"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -104,6 +112,8 @@
             v-model="payment.days_of_prior_notice"
             label="Days of prior notice*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="remove-button">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/Rational.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/Rational.vue
@@ -19,13 +19,15 @@
       <v-expansion-panel-content>
         <div class="expand-content">
           <div class="title-text-area">Offer Comments*</div>
-          <textarea
+          <v-textarea
             v-model.trim="rationalComments"
             @blur="updateByColumn('rational_comments', $event.target.value)"
             @input="
               $emit('rational-comments-change', rationalCommentsCompleted)
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/RiskProfile.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/RiskProfile.vue
@@ -20,13 +20,15 @@
         <div class="expand-content">
           <div class="title-text-area">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="riskProfileComments"
             @change="
               updateByColumn('risk_profile_comments', $event.target.value)
             "
             @input="$emit('risk-profile-change', riskProfileCompleted)"
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
 
           <div class="inputs-cont">
             <div class="input-cont">
@@ -38,6 +40,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_clause', $event);
                   $emit('risk-profile-change', riskProfileCompleted);
@@ -54,6 +58,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_exposure', $event);
                   $emit('risk-profile-change', riskProfileCompleted);
@@ -70,6 +76,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_housekeeping', $event);
                   $emit('risk-profile-change', riskProfileCompleted);

--- a/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
@@ -50,6 +50,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('underwriter', 'boundEng')"
       ></v-select>
     </div>
 

--- a/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
@@ -52,7 +52,9 @@
         :disabled="underwriter.length === 0"
         hint="Required field"
         persistent-hint
-        :error-messages="requiredInputVuelidateParent('underwriter', 'boundEng')"
+        :error-messages="
+          requiredInputVuelidateParent('underwriter', 'boundEng')
+        "
       ></v-select>
     </div>
 
@@ -68,6 +70,11 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="
+          requiredInputVuelidateParent('underwriter', 'boundEng')
+        "
       ></v-select>
     </div>
     <div class="inputCont">

--- a/src/components/subscription/bound/propertyQuotatorProportional/MainLocation.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/MainLocation.vue
@@ -21,6 +21,8 @@
               SET_MLIV_BOUND('damage', this);
               checkField('damage');
             "
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">

--- a/src/components/subscription/bound/propertyQuotatorProportional/PmlProperty.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/PmlProperty.vue
@@ -21,6 +21,8 @@
               SET_BOUND_PML('pmlDamage', this);
               checkField('pmlDamage');
             "
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -84,14 +86,16 @@
     </div>
 
     <div class="TitleTextArea">PML Comments*</div>
-    <textarea
+    <v-textarea
       v-model="$v.boundPml.pmlComments.$model"
       @blur="
         SET_BOUND_PML('pmlComments', this);
         checkField('pmlComments');
       "
       placeholder="Please enter PML comments"
-    ></textarea>
+      hint="Required field"
+      persistent-hint
+    />
   </div>
 </template>
 <script>


### PR DESCRIPTION
## Summary
- show persistent "Required field" hints for critical underwriting selects
- validate underwriter and analyst fields across engineering and property quotators

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aab05e0a88832c84c93763d9e38a38