### PR TITLE
feat: highlight required risk fields

### DIFF
--- a/src/components/CurrencyInput/CurrencyInput.vue
+++ b/src/components/CurrencyInput/CurrencyInput.vue
@@ -9,6 +9,8 @@
     :readonly="readonly"
     :disabled="disabled"
     :label="label"
+    :hint="hint"
+    :persistent-hint="persistentHint"
     @blur="onBlur()"
   />
 </template>
@@ -63,6 +65,14 @@ export default {
     label: {
       type: String,
       default: "",
+    },
+    hint: {
+      type: String,
+      default: null,
+    },
+    persistentHint: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props) {

--- a/src/components/subscription/bound/engineering/BoundClaims.vue
+++ b/src/components/subscription/bound/engineering/BoundClaims.vue
@@ -33,6 +33,8 @@
                   :options="currencyOptions"
                   @input="update(key, item.model)"
                   @blur="saveData(key, 'columnModel', item.model)"
+                  hint="Required field"
+                  persistent-hint
                 />
               </div>
               <div class="Row Large">

--- a/src/components/subscription/bound/engineering/InputsRisk.vue
+++ b/src/components/subscription/bound/engineering/InputsRisk.vue
@@ -50,6 +50,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('underwriter', 'boundEng')"
       ></v-select>
     </div>
 
@@ -65,6 +68,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('awAnalist1', 'boundEng')"
       ></v-select>
     </div>
     <div class="inputCont">

--- a/src/components/subscription/bound/engineering/PremiumPaymentWarranty.vue
+++ b/src/components/subscription/bound/engineering/PremiumPaymentWarranty.vue
@@ -23,6 +23,8 @@
             v-model="payment.installment"
             :label="'Installment ' + (index + 1) + '*'"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -38,6 +40,8 @@
             v-model="payment.percent"
             label="Percentage*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -55,6 +59,8 @@
                 label="PPW Due Date*"
                 v-bind="attrs"
                 v-on="on"
+                hint="Required field"
+                persistent-hint
               />
             </template>
             <v-date-picker
@@ -88,6 +94,8 @@
             item-value="id"
             item-text="clause"
             :items="clauseList"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -104,6 +112,8 @@
             v-model="payment.days_of_prior_notice"
             label="Days of prior notice*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
 

--- a/src/components/subscription/bound/engineering/Rational.vue
+++ b/src/components/subscription/bound/engineering/Rational.vue
@@ -20,13 +20,15 @@
         <div class="ExpandContent">
           <div class="TitleTextArea">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="$v.boundEng.rationalComments.$model"
             @blur="
               SET_BOUND_ENG('rationalComments', this);
               checkField('rationalComments');
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>

--- a/src/components/subscription/bound/engineering/RiskAnalysis.vue
+++ b/src/components/subscription/bound/engineering/RiskAnalysis.vue
@@ -25,7 +25,10 @@
       <!--CONTENIDO DEL ACORDEON-->
       <v-expansion-panel-content>
         <div class="ExpandContent">
-          <InputsRisk @required-fields-change="onRequiredFieldsChange" />
+          <InputsRisk
+            ref="inputsRisk"
+            @required-fields-change="onRequiredFieldsChange"
+          />
           <RiskInformation />
           <!-- <CedentInformation /> -->
           <Deductions />
@@ -74,17 +77,25 @@
           </div>
 
           <PremiumPaymentWarranty
+            ref="premiumPaymentWarranty"
             @payments-warranty-change="onPaymentsWarrantyChange"
           />
           <BoundClaims
+            ref="boundClaims"
             :selectedRiskKey="selectedRiskKey"
             @bound-claims-change="onBoundClaimsChange"
           />
 
           <div class="ExpansionLineTop mt-2" />
 
-          <Rational @rational-comments-change="onRationalCommentsChange" />
-          <RiskProfile @risk-profile-change="onRiskProfileChange" />
+          <Rational
+            ref="rational"
+            @rational-comments-change="onRationalCommentsChange"
+          />
+          <RiskProfile
+            ref="riskProfile"
+            @risk-profile-change="onRiskProfileChange"
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>
@@ -251,6 +262,60 @@ export default {
     onRiskProfileChange(isComplete) {
       this.riskProfileCompleted = isComplete;
       this.emitValidationStatus();
+    },
+
+    scrollToFirstInvalid() {
+      if (!this.requiredFieldsCompleted && this.$refs.inputsRisk) {
+        this.$refs.inputsRisk.$v.boundEng.$touch();
+        this.$nextTick(() =>
+          this.$refs.inputsRisk.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.paymentsWarrantyCompleted && this.$refs.premiumPaymentWarranty) {
+        this.$nextTick(() =>
+          this.$refs.premiumPaymentWarranty.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.boundClaimsCompleted && this.$refs.boundClaims) {
+        this.$nextTick(() =>
+          this.$refs.boundClaims.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.rationalCommentsCompleted && this.$refs.rational) {
+        this.$refs.rational.$v.boundEng.rationalComments.$touch();
+        this.$nextTick(() =>
+          this.$refs.rational.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.riskProfileCompleted && this.$refs.riskProfile) {
+        const v = this.$refs.riskProfile.$v.boundEng;
+        v.riskProfileComments.$touch();
+        v.riskProfileClause.$touch();
+        v.riskProfileExposure.$touch();
+        v.riskProfileHousekeeping.$touch();
+        this.$nextTick(() =>
+          this.$refs.riskProfile.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+      }
     },
 
     emitValidationStatus() {

--- a/src/components/subscription/bound/engineering/RiskProfile.vue
+++ b/src/components/subscription/bound/engineering/RiskProfile.vue
@@ -20,13 +20,15 @@
         <div class="ExpandContent">
           <div class="TitleTextArea">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="$v.boundEng.riskProfileComments.$model"
             @blur="
               SET_BOUND_ENG('riskProfileComments', this);
               checkField('riskProfileComments');
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
 
           <div class="InputsCont d-flex justify-start align-center">
             <div class="InputCont">
@@ -42,6 +44,8 @@
                 item-value="id"
                 clearable
                 :disabled="typeClause.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
             <div class="InputCont">
@@ -57,6 +61,8 @@
                 item-value="id"
                 clearable
                 :disabled="exposure.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
             <div class="InputCont">
@@ -72,6 +78,8 @@
                 item-value="id"
                 clearable
                 :disabled="housekeeping.length === 0"
+                hint="Required field"
+                persistent-hint
               ></v-select>
             </div>
           </div>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/Claims.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/Claims.vue
@@ -34,6 +34,8 @@
                     :options="currencyOptions"
                     @blur="updateByColumn('amount', item.amount, item.sub)"
                     @input="$emit('bound-claims-change', boundClaimsCompleted)"
+                    hint="Required field"
+                    persistent-hint
                   />
                 </div>
                 <div class="input-row large">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/InputsRiskQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/InputsRiskQuotator.vue
@@ -33,6 +33,9 @@
         item-text="data"
         item-value="id"
         :disabled="disabled"
+        hint="Required field"
+        persistent-hint
+        :rules="[(v) => !!v || 'Required field']"
       ></v-select>
     </div>
     <div class="input-cont">
@@ -44,6 +47,9 @@
         item-text="data"
         item-value="id"
         :disabled="disabled"
+        hint="Required field"
+        persistent-hint
+        :rules="[(v) => !!v || 'Required field']"
       >
       </v-select>
     </div>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/MainLocation.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/MainLocation.vue
@@ -18,6 +18,8 @@
               v-model="mainLocation.damage"
               @blur="saveField('damage', mainLocation.damage)"
               :options="currencyOptions"
+              hint="Required field"
+              persistent-hint
             />
           </div>
           <div class="input-row">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/PmlProperty.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/PmlProperty.vue
@@ -22,6 +22,8 @@
               min="0"
               max="100"
               step="1"
+              hint="Required field"
+              persistent-hint
             />
           </div>
           <div class="input-row">
@@ -44,11 +46,13 @@
     </div>
 
     <div class="title-text-area">PML Comments*</div>
-    <textarea
+    <v-textarea
       v-model="pmlProperty.comments"
       @blur="saveField('comments', pmlProperty.comments)"
       @input="handleCommentsChange"
-    ></textarea>
+      hint="Required field"
+      persistent-hint
+    />
   </div>
 </template>
 <script>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/PremiumPaymentWarranty.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/PremiumPaymentWarranty.vue
@@ -23,6 +23,8 @@
             v-model="payment.installment"
             :label="'Installment ' + (index + 1) + '*'"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -38,6 +40,8 @@
             v-model="payment.percent"
             label="Percentage*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -55,6 +59,8 @@
                 label="PPW Due Date*"
                 v-bind="attrs"
                 v-on="on"
+                hint="Required field"
+                persistent-hint
               />
             </template>
             <v-date-picker
@@ -88,6 +94,8 @@
             item-value="id"
             item-text="clause"
             :items="clauseList"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -104,6 +112,8 @@
             v-model="payment.days_of_prior_notice"
             label="Days of prior notice*"
             type="number"
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="remove-button">

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/Rational.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/Rational.vue
@@ -19,13 +19,15 @@
       <v-expansion-panel-content>
         <div class="expand-content">
           <div class="title-text-area">Offer Comments*</div>
-          <textarea
+          <v-textarea
             v-model.trim="rationalComments"
             @blur="updateByColumn('rational_comments', $event.target.value)"
             @input="
               $emit('rational-comments-change', rationalCommentsCompleted)
             "
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/RiskAnalysisQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/RiskAnalysisQuotator.vue
@@ -27,6 +27,7 @@
       <v-expansion-panel-content>
         <div class="ExpandContent">
           <InputsRiskQuotator
+            ref="inputsRisk"
             @required-fields-change="onRequiredFieldsChange"
           />
 
@@ -53,11 +54,15 @@
             class="my-10"
           />
 
-          <MainLocation @damage-field-change="onDamageFieldChange" />
+          <MainLocation
+            ref="mainLocation"
+            @damage-field-change="onDamageFieldChange"
+          />
 
           <div class="expansion-line-top mt-2" />
 
           <PmlProperty
+            ref="pmlProperty"
             :exchangeRate="Number(quotation.exchangeRate) || 1"
             @pml-fields-change="onPmlFieldsChange"
           />
@@ -105,13 +110,23 @@
           </div>
 
           <PremiumPaymentWarranty
+            ref="premiumPaymentWarranty"
             @payments-warranty-change="onPaymentsWarrantyChange"
           />
-          <Claims @bound-claims-change="onBoundClaimsChange" />
+          <Claims
+            ref="boundClaims"
+            @bound-claims-change="onBoundClaimsChange"
+          />
 
           <div class="expansion-line-top mt-2" />
-          <Rational @rational-comments-change="onRationalCommentsChange" />
-          <RiskProfile @risk-profile-change="onRiskProfileChange" />
+          <Rational
+            ref="rational"
+            @rational-comments-change="onRationalCommentsChange"
+          />
+          <RiskProfile
+            ref="riskProfile"
+            @risk-profile-change="onRiskProfileChange"
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>
@@ -312,6 +327,78 @@ export default {
     onRiskProfileChange(isComplete) {
       this.riskProfileCompleted = isComplete;
       this.emitValidationStatus();
+    },
+
+    scrollToFirstInvalid() {
+      if (!this.requiredFieldsCompleted && this.$refs.inputsRisk) {
+        this.$refs.inputsRisk.$v.boundEng.$touch();
+        this.$nextTick(() =>
+          this.$refs.inputsRisk.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.damageFieldCompleted && this.$refs.mainLocation) {
+        this.$nextTick(() =>
+          this.$refs.mainLocation.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.pmlFieldsCompleted && this.$refs.pmlProperty) {
+        this.$nextTick(() =>
+          this.$refs.pmlProperty.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.paymentsWarrantyCompleted && this.$refs.premiumPaymentWarranty) {
+        this.$nextTick(() =>
+          this.$refs.premiumPaymentWarranty.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.boundClaimsCompleted && this.$refs.boundClaims) {
+        this.$nextTick(() =>
+          this.$refs.boundClaims.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.rationalCommentsCompleted && this.$refs.rational) {
+        this.$refs.rational.$v.boundEng.rationalComments.$touch();
+        this.$nextTick(() =>
+          this.$refs.rational.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.riskProfileCompleted && this.$refs.riskProfile) {
+        const v = this.$refs.riskProfile.$v.boundEng;
+        v.riskProfileComments.$touch();
+        v.riskProfileClause.$touch();
+        v.riskProfileExposure.$touch();
+        v.riskProfileHousekeeping.$touch();
+        this.$nextTick(() =>
+          this.$refs.riskProfile.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+      }
     },
 
     emitValidationStatus() {

--- a/src/components/subscription/bound/propertyQuotatorNonProportional/RiskProfile.vue
+++ b/src/components/subscription/bound/propertyQuotatorNonProportional/RiskProfile.vue
@@ -20,13 +20,15 @@
         <div class="expand-content">
           <div class="title-text-area">Offer Comments*</div>
 
-          <textarea
+          <v-textarea
             v-model.trim="riskProfileComments"
             @change="
               updateByColumn('risk_profile_comments', $event.target.value)
             "
             @input="$emit('risk-profile-change', riskProfileCompleted)"
-          ></textarea>
+            hint="Required field"
+            persistent-hint
+          />
 
           <div class="inputs-cont">
             <div class="input-cont">
@@ -38,6 +40,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_clause', $event);
                   $emit('risk-profile-change', riskProfileCompleted);
@@ -54,6 +58,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_exposure', $event);
                   $emit('risk-profile-change', riskProfileCompleted);
@@ -70,6 +76,8 @@
                 item-value="id"
                 clearable
                 :disabled="disabled"
+                hint="Required field"
+                persistent-hint
                 @change="
                   updateByColumn('risk_profile_housekeeping', $event);
                   $emit('risk-profile-change', riskProfileCompleted);

--- a/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/InputsRiskQuotator.vue
@@ -50,6 +50,9 @@
         item-text="data"
         item-value="id"
         :disabled="underwriter.length === 0"
+        hint="Required field"
+        persistent-hint
+        :error-messages="requiredInputVuelidateParent('underwriter', 'boundEng')"
       ></v-select>
     </div>
 

--- a/src/components/subscription/bound/propertyQuotatorProportional/MainLocation.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/MainLocation.vue
@@ -21,6 +21,8 @@
               SET_MLIV_BOUND('damage', this);
               checkField('damage');
             "
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">

--- a/src/components/subscription/bound/propertyQuotatorProportional/PmlProperty.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/PmlProperty.vue
@@ -21,6 +21,8 @@
               SET_BOUND_PML('pmlDamage', this);
               checkField('pmlDamage');
             "
+            hint="Required field"
+            persistent-hint
           />
         </div>
         <div class="Row">
@@ -84,14 +86,16 @@
     </div>
 
     <div class="TitleTextArea">PML Comments*</div>
-    <textarea
+    <v-textarea
       v-model="$v.boundPml.pmlComments.$model"
       @blur="
         SET_BOUND_PML('pmlComments', this);
         checkField('pmlComments');
       "
       placeholder="Please enter PML comments"
-    ></textarea>
+      hint="Required field"
+      persistent-hint
+    />
   </div>
 </template>
 <script>

--- a/src/components/subscription/bound/propertyQuotatorProportional/RiskAnalysisQuotator.vue
+++ b/src/components/subscription/bound/propertyQuotatorProportional/RiskAnalysisQuotator.vue
@@ -26,6 +26,7 @@
       <v-expansion-panel-content>
         <div class="ExpandContent">
           <InputsRiskQuotator
+            ref="inputsRisk"
             @required-fields-change="onRequiredFieldsChange"
           />
 
@@ -43,11 +44,17 @@
             v-if="propEng && propEng != ''"
           />
 
-          <MainLocation @damage-field-change="onDamageFieldChange" />
+          <MainLocation
+            ref="mainLocation"
+            @damage-field-change="onDamageFieldChange"
+          />
 
           <div class="ExpansionLineTop mt-2" />
 
-          <PmlProperty @pml-fields-change="onPmlFieldsChange" />
+          <PmlProperty
+            ref="pmlProperty"
+            @pml-fields-change="onPmlFieldsChange"
+          />
 
           <div class="ExpansionLineTop mt-7" />
 
@@ -90,15 +97,25 @@
           </div>
 
           <PremiumPaymentWarranty
+            ref="premiumPaymentWarranty"
             @payments-warranty-change="onPaymentsWarrantyChange"
           />
 
-          <BoundClaims @bound-claims-change="onBoundClaimsChange" />
+          <BoundClaims
+            ref="boundClaims"
+            @bound-claims-change="onBoundClaimsChange"
+          />
 
           <div class="ExpansionLineTop mt-2" />
-          <Rational @rational-comments-change="onRationalCommentsChange" />
+          <Rational
+            ref="rational"
+            @rational-comments-change="onRationalCommentsChange"
+          />
 
-          <RiskProfile @risk-profile-change="onRiskProfileChange" />
+          <RiskProfile
+            ref="riskProfile"
+            @risk-profile-change="onRiskProfileChange"
+          />
         </div>
       </v-expansion-panel-content>
     </v-expansion-panel>
@@ -266,6 +283,78 @@ export default {
     onRiskProfileChange(isComplete) {
       this.riskProfileCompleted = isComplete;
       this.emitValidationStatus();
+    },
+
+    scrollToFirstInvalid() {
+      if (!this.requiredFieldsCompleted && this.$refs.inputsRisk) {
+        this.$refs.inputsRisk.$v.boundEng.$touch();
+        this.$nextTick(() =>
+          this.$refs.inputsRisk.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.damageFieldCompleted && this.$refs.mainLocation) {
+        this.$nextTick(() =>
+          this.$refs.mainLocation.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.pmlFieldsCompleted && this.$refs.pmlProperty) {
+        this.$nextTick(() =>
+          this.$refs.pmlProperty.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.paymentsWarrantyCompleted && this.$refs.premiumPaymentWarranty) {
+        this.$nextTick(() =>
+          this.$refs.premiumPaymentWarranty.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.boundClaimsCompleted && this.$refs.boundClaims) {
+        this.$nextTick(() =>
+          this.$refs.boundClaims.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.rationalCommentsCompleted && this.$refs.rational) {
+        this.$refs.rational.$v.boundEng.rationalComments.$touch();
+        this.$nextTick(() =>
+          this.$refs.rational.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+        return;
+      }
+      if (!this.riskProfileCompleted && this.$refs.riskProfile) {
+        const v = this.$refs.riskProfile.$v.boundEng;
+        v.riskProfileComments.$touch();
+        v.riskProfileClause.$touch();
+        v.riskProfileExposure.$touch();
+        v.riskProfileHousekeeping.$touch();
+        this.$nextTick(() =>
+          this.$refs.riskProfile.$el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          })
+        );
+      }
     },
 
     emitValidationStatus() {

--- a/src/views/Subscription/BoundEngineering.vue
+++ b/src/views/Subscription/BoundEngineering.vue
@@ -57,17 +57,19 @@
       </div>
       <!--BOTON PARA FINALIZAR-->
       <div class="finishButtonCont mt-7 d-flex justify-end align-center">
-        <v-btn
-          v-if="showFacultativeButton"
-          rounded
-          large
-          text
-          class="finishBtn"
-          @click="sendToFacultative"
-          :disabled="!buttonsEnabled"
-        >
-          Send To Facultative
-        </v-btn>
+        <div @click="onSendToFacultative">
+          <v-btn
+            v-if="showFacultativeButton"
+            rounded
+            large
+            text
+            class="finishBtn"
+            @click.stop
+            :disabled="!buttonsEnabled"
+          >
+            Send To Facultative
+          </v-btn>
+        </div>
       </div>
 
       <!--ESPACIO EN BLANCO-->
@@ -241,10 +243,21 @@ export default {
         }, 50);
       }
     },
+    onSendToFacultative() {
+      if (this.buttonsEnabled) {
+        this.sendToFacultative();
+      } else {
+        this.scrollToFirstInvalid();
+      }
+    },
     async sendToFacultative() {
       const subscriptionId = Number(this.subscriptionId);
       await AccountCompleteService.addInitialRegister(subscriptionId);
       this.$router.push({ name: "Subs home" });
+    },
+
+    scrollToFirstInvalid() {
+      this.$refs.riskAnalysis?.scrollToFirstInvalid();
     },
 
     async saveNatcatDocument({ subscription_id, doc_s3 }) {},

--- a/src/views/Subscription/BoundPropertyQuotatorNonProportional.vue
+++ b/src/views/Subscription/BoundPropertyQuotatorNonProportional.vue
@@ -65,17 +65,19 @@
 
       <!--BOTON PARA FINALIZAR-->
       <div class="finish-button-cont">
-        <v-btn
-          v-if="showFacultativeButton"
-          rounded
-          large
-          text
-          class="finish-btn"
-          @click="sendToFacultative"
-          :disabled="!buttonsEnabled"
-        >
-          Send To Facultative
-        </v-btn>
+        <div @click="onSendToFacultative">
+          <v-btn
+            v-if="showFacultativeButton"
+            rounded
+            large
+            text
+            class="finish-btn"
+            @click.stop
+            :disabled="!buttonsEnabled"
+          >
+            Send To Facultative
+          </v-btn>
+        </div>
       </div>
 
       <!--ESPACIO EN BLANCO-->
@@ -190,6 +192,13 @@ export default {
         checkDisableInputsFile();
       }
     },
+    onSendToFacultative() {
+      if (this.buttonsEnabled) {
+        this.sendToFacultative();
+      } else {
+        this.scrollToFirstInvalid();
+      }
+    },
     async sendToFacultative() {
       const subscriptionId = Number(this.subscriptionId);
       await AccountCompleteNonPropServices.addInitialRegister(subscriptionId);
@@ -200,6 +209,9 @@ export default {
     },
     onAllRequiredFieldsComplete(isComplete) {
       this.requiredFieldsCompleted = isComplete;
+    },
+    scrollToFirstInvalid() {
+      this.$refs.riskAnalysisQuotator?.scrollToFirstInvalid();
     },
   },
 };

--- a/src/views/Subscription/BoundPropertyQuotatorProportional.vue
+++ b/src/views/Subscription/BoundPropertyQuotatorProportional.vue
@@ -49,30 +49,34 @@
       </div>
       <!-- <ExtensionAndEndorsements /> -->
       <div class="finishButtonCont mt-7 d-flex justify-end align-center">
-        <v-btn
-          v-if="showFacultativeButton"
-          rounded
-          large
-          text
-          class="finishBtn"
-          :disabled="!buttonsEnabled"
-          @click="sendToFacultative"
-        >
-          Send To Facultative
-        </v-btn>
+        <div @click="onSendToFacultative">
+          <v-btn
+            v-if="showFacultativeButton"
+            rounded
+            large
+            text
+            class="finishBtn"
+            :disabled="!buttonsEnabled"
+            @click.stop
+          >
+            Send To Facultative
+          </v-btn>
+        </div>
       </div>
       <!--Botón crear wallet-->
       <div class="finishButtonCont mt-2 d-flex justify-end align-center">
-        <v-btn
-          rounded
-          large
-          text
-          class="finishBtn"
-          :disabled="!buttonsEnabled"
-          @click="createWallet"
-        >
-          Create Wallet
-        </v-btn>
+        <div @click="onCreateWallet">
+          <v-btn
+            rounded
+            large
+            text
+            class="finishBtn"
+            :disabled="!buttonsEnabled"
+            @click.stop
+          >
+            Create Wallet
+          </v-btn>
+        </div>
       </div>
       <!--ESPACIO EN BLANCO-->
       <WhiteSpace />
@@ -264,10 +268,24 @@ export default {
         checkDisableInputsFile();
       }
     },
+    onSendToFacultative() {
+      if (this.buttonsEnabled) {
+        this.sendToFacultative();
+      } else {
+        this.scrollToFirstInvalid();
+      }
+    },
     async sendToFacultative() {
       const subscriptionId = Number(this.subscriptionId);
       await AccountCompleteService.addInitialRegister(subscriptionId);
       this.$router.push({ name: "Subs home" });
+    },
+    onCreateWallet() {
+      if (this.buttonsEnabled) {
+        this.createWallet();
+      } else {
+        this.scrollToFirstInvalid();
+      }
     },
     // TODO:definir bien donde ira este servicio
     async createWallet() {
@@ -297,6 +315,9 @@ export default {
     },
     onAllRequiredFieldsComplete(isComplete) {
       this.requiredFieldsCompleted = isComplete;
+    },
+    scrollToFirstInvalid() {
+      this.$refs.riskAnalysisQuotator?.scrollToFirstInvalid();
     },
   },
 };


### PR DESCRIPTION
## Summary
- add reusable hint support to currency inputs
- display persistent "Required field" help for all validated risk analysis inputs
- scroll to the first incomplete risk field when disabled actions are pressed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aab05e0a88832c84c93763d9e38a38