### PR TITLE
Fix endorsement numeric handling and tooltip directive

### DIFF
--- a/src/modules/home/modules/endorsements/components/AppFile.vue
+++ b/src/modules/home/modules/endorsements/components/AppFile.vue
@@ -3,7 +3,7 @@
     <!-- Muestra el archivo -->
     <div v-if="loaded" class="file">
       <!-- Header / Nombre del archivo -->
-      <div @click="downloadFile" class="file__header" v-tooltip="'Open'">
+      <div @click="downloadFile" class="file__header" :title="'Open'">
         {{ fileName }}
       </div>
 

--- a/src/modules/home/modules/endorsements/engineering/components/DeductionsChange.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/DeductionsChange.vue
@@ -536,6 +536,12 @@ export default {
     },
   },
   methods: {
+    validateNumericValue(value, defaultValue = 0) {
+      if (value === null || value === undefined || isNaN(Number(value))) {
+        return defaultValue;
+      }
+      return Number(value);
+    },
     setTotalPremium({ id, value, concept }) {
       const totalPremium = this.totalPremium.find((el) => el.id === id);
       totalPremium[concept] = value;
@@ -576,9 +582,18 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium = this.accountComplete.net_premium.originalValues.netSluExcludingSurveyFeesTotal;
-      const newNetPremium = this.resultOriginalCurenncy.data.netSLUExcludingSurveyFeesTotal;
-      const netPremiumDifference = Decimal(Decimal(newNetPremium)).sub(Decimal(originalNetPremium)).toNumber();
+      const originalNetPremium = this.validateNumericValue(
+        this.accountComplete.net_premium?.originalValues
+          ?.netSluExcludingSurveyFeesTotal,
+        0
+      );
+      const newNetPremium = this.validateNumericValue(
+        this.resultOriginalCurenncy?.data?.netSLUExcludingSurveyFeesTotal,
+        0
+      );
+      const netPremiumDifference = Decimal(newNetPremium)
+        .sub(originalNetPremium)
+        .toNumber();
 
       // guardar la cuenta actualizada en BD
 

--- a/src/modules/home/modules/endorsements/engineering/components/ExclusionRisk.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/ExclusionRisk.vue
@@ -720,6 +720,12 @@ export default {
     },
   },
   methods: {
+    validateNumericValue(value, defaultValue = 0) {
+      if (value === null || value === undefined || isNaN(Number(value))) {
+        return defaultValue;
+      }
+      return Number(value);
+    },
     toUsd(value) {
       const exchangeRate = this.accountComplete.deductibles.exchangeRate;
       return Decimal.div(value, exchangeRate).toNumber();
@@ -823,20 +829,24 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium =
-        this.accountComplete.net_premium.originalValues
-          .netSluExcludingSurveyFeesTotal;
+      const originalNetPremium = this.validateNumericValue(
+        this.accountComplete.net_premium?.originalValues
+          ?.netSluExcludingSurveyFeesTotal,
+        0
+      );
 
-      const netPremiumMovement =
-        this.netPremium.originalValues.netSLUExcludingSurveyFeesTotal;
+      const netPremiumMovement = this.validateNumericValue(
+        this.netPremium?.originalValues?.netSLUExcludingSurveyFeesTotal,
+        0
+      );
 
       const newNetPremium = Decimal.sub(
         originalNetPremium,
         netPremiumMovement
       ).toNumber();
 
-      const netPremiumDifference = Decimal(Decimal(newNetPremium))
-        .sub(Decimal(originalNetPremium))
+      const netPremiumDifference = Decimal(newNetPremium)
+        .sub(originalNetPremium)
         .toNumber();
 
       // Obteniendo el insurable

--- a/src/modules/home/modules/endorsements/engineering/components/Extension.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/Extension.vue
@@ -762,6 +762,12 @@ export default {
     },
   },
   methods: {
+    validateNumericValue(value, defaultValue = 0) {
+      if (value === null || value === undefined || isNaN(Number(value))) {
+        return defaultValue;
+      }
+      return Number(value);
+    },
     calcPremium() {
       const tiv = this.accountComplete.tiv;
       const tivMovement = {
@@ -882,20 +888,24 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium =
-        this.accountComplete.net_premium.originalValues
-          .netSluExcludingSurveyFeesTotal;
+      const originalNetPremium = this.validateNumericValue(
+        this.accountComplete.net_premium?.originalValues
+          ?.netSluExcludingSurveyFeesTotal,
+        0
+      );
 
-      const netPremiumMovement =
-        this.netPremium.originalValues.netSLUExcludingSurveyFeesTotal;
+      const netPremiumMovement = this.validateNumericValue(
+        this.netPremium?.originalValues?.netSLUExcludingSurveyFeesTotal,
+        0
+      );
 
       const newNetPremium = Decimal.add(
         originalNetPremium,
         netPremiumMovement
       ).toNumber();
 
-      const netPremiumDifference = Decimal(Decimal(newNetPremium))
-        .sub(Decimal(originalNetPremium))
+      const netPremiumDifference = Decimal(newNetPremium)
+        .sub(originalNetPremium)
         .toNumber();
 
       // Obteniendo el insurable

--- a/src/modules/home/modules/endorsements/engineering/components/InclusionRisk.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/InclusionRisk.vue
@@ -823,20 +823,24 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium =
-        this.accountComplete.net_premium.originalValues
-          .netSluExcludingSurveyFeesTotal;
+      const originalNetPremium = this.validateNumericValue(
+        this.accountComplete.net_premium?.originalValues
+          ?.netSluExcludingSurveyFeesTotal,
+        0
+      );
 
-      const netPremiumMovement =
-        this.netPremium.originalValues.netSLUExcludingSurveyFeesTotal;
+      const netPremiumMovement = this.validateNumericValue(
+        this.netPremium?.originalValues?.netSLUExcludingSurveyFeesTotal,
+        0
+      );
 
       const newNetPremium = Decimal.add(
         originalNetPremium,
         netPremiumMovement
       ).toNumber();
 
-      const netPremiumDifference = Decimal(Decimal(newNetPremium))
-        .sub(Decimal(originalNetPremium))
+      const netPremiumDifference = Decimal(newNetPremium)
+        .sub(originalNetPremium)
         .toNumber();
 
       // Obteniendo el insurable

--- a/src/modules/home/modules/endorsements/engineering/components/MovementValues.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/MovementValues.vue
@@ -331,19 +331,22 @@ export default {
         case 1: // Original currency action
           switch (concept) {
             case 'damage':
-              this.movementValuesComputed[1].damage = Decimal(!value ? 0 : Decimal(value)).div(
-                Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].damage = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
 
             case 'bi':
-              this.movementValuesComputed[1].bi = Decimal(!value ? 0 : Decimal(value)).div(
-                Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].bi = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
 
             case 'stocks':
-              this.movementValuesComputed[1].stocks = Decimal(!value ? 0 : Decimal(value)).div(
-                Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].stocks = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
           }
         case 2: // USD action
           return 29;

--- a/src/modules/home/modules/endorsements/engineering/components/MovementValuesEng.vue
+++ b/src/modules/home/modules/endorsements/engineering/components/MovementValuesEng.vue
@@ -215,13 +215,15 @@ export default {
         case 1: // Original currency action
           switch (concept) {
             case 'allRisk':
-              this.movementValuesComputed[1].allRisk = Decimal(!value ? 0 : Decimal(value)).div(
-                Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].allRisk = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
             case 'alop':
-              this.movementValuesComputed[1].alop = Decimal(!value ? 0 : Decimal(value)).div(
-                Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].alop = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
           }
         case 2: // USD action
           return 29;

--- a/src/modules/home/modules/endorsements/property-quotator/components/BiAdjustments.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/BiAdjustments.vue
@@ -1269,16 +1269,19 @@ export default {
       this.accountComplete.tiv.insurable.total = premiumOriginal.premiumTotal;
       this.accountComplete.tiv.insurable.totalUsd = premiumUSD.premiumTotal;
 
-      // calcular diferencia del net premium
-      const originalNetPremium = removeDollarSign(
-        this.accountComplete.net_premium.originalValues.netTotal
-      );
-      const newNetPremium = removeDollarSign(
-        this.netPremium.originalValues.netTotal
-      );
-      const netPremiumDifference = Decimal(Decimal(newNetPremium))
-        .sub(Decimal(originalNetPremium))
-        .toNumber();
+        // calcular diferencia del net premium
+        const originalNetPremium =
+          Number(
+            removeDollarSign(
+              this.accountComplete.net_premium?.originalValues?.netTotal
+            )
+          ) || 0;
+        const newNetPremium =
+          Number(removeDollarSign(this.netPremium?.originalValues?.netTotal)) ||
+          0;
+        const netPremiumDifference = Decimal(newNetPremium)
+          .sub(originalNetPremium)
+          .toNumber();
 
       // Actualizar netPremium
       this.accountComplete.net_premium = this.netPremium;

--- a/src/modules/home/modules/endorsements/property-quotator/components/Cancellation.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/Cancellation.vue
@@ -584,9 +584,17 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium = removeDollarSign(this.accountComplete.net_premium.originalValues.netTotal);
+      const originalNetPremium =
+        Number(
+          removeDollarSign(
+            this.accountComplete.net_premium?.originalValues?.netTotal
+          )
+        ) || 0;
 
-      const netPremiumMovement = removeDollarSign(this.netPremium.originalValues.netTotal);
+      const netPremiumMovement =
+        Number(
+          removeDollarSign(this.netPremium?.originalValues?.netTotal)
+        ) || 0;
 
       const newNetPremium = Decimal.add(originalNetPremium, netPremiumMovement).toNumber();
 

--- a/src/modules/home/modules/endorsements/property-quotator/components/DeductionsChange.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/DeductionsChange.vue
@@ -889,9 +889,19 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium = removeDollarSign(this.accountComplete.net_premium.originalValues.netTotal);
-      const newNetPremium = removeDollarSign(this.resultOriginalCurenncy.data.netTotal);
-      const netPremiumDifference = Decimal(Decimal(newNetPremium)).sub(Decimal(originalNetPremium)).toNumber();
+      const originalNetPremium =
+        Number(
+          removeDollarSign(
+            this.accountComplete.net_premium?.originalValues?.netTotal
+          )
+        ) || 0;
+      const newNetPremium =
+        Number(
+          removeDollarSign(this.resultOriginalCurenncy?.data?.netTotal)
+        ) || 0;
+      const netPremiumDifference = Decimal(newNetPremium)
+        .sub(originalNetPremium)
+        .toNumber();
 
       const accountCompleteResponse = await accountCompleteService.addAccountComplete(this.subscriptionId, {
         ...this.accountComplete,

--- a/src/modules/home/modules/endorsements/property-quotator/components/Extension.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/Extension.vue
@@ -907,13 +907,17 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium = removeDollarSign(
-        this.accountComplete.net_premium.originalValues.netTotal
-      );
+      const originalNetPremium =
+        Number(
+          removeDollarSign(
+            this.accountComplete.net_premium?.originalValues?.netTotal
+          )
+        ) || 0;
 
-      const netPremiumMovement = removeDollarSign(
-        this.netPremium.originalValues.netTotal
-      );
+      const netPremiumMovement =
+        Number(
+          removeDollarSign(this.netPremium?.originalValues?.netTotal)
+        ) || 0;
 
       const newNetPremium = Decimal.add(
         originalNetPremium,

--- a/src/modules/home/modules/endorsements/property-quotator/components/InclusionRisk.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/InclusionRisk.vue
@@ -858,13 +858,17 @@ export default {
       this.e1 = 1;
 
       // calcular diferencia del net premium
-      const originalNetPremium = removeDollarSign(
-        this.accountComplete.net_premium.originalValues.netTotal
-      );
+      const originalNetPremium =
+        Number(
+          removeDollarSign(
+            this.accountComplete.net_premium?.originalValues?.netTotal
+          )
+        ) || 0;
 
-      const netPremiumMovement = removeDollarSign(
-        this.netPremium.originalValues.netTotal
-      );
+      const netPremiumMovement =
+        Number(
+          removeDollarSign(this.netPremium?.originalValues?.netTotal)
+        ) || 0;
 
       const newNetPremium = Decimal.add(
         originalNetPremium,

--- a/src/modules/home/modules/endorsements/property-quotator/components/MovementValues.vue
+++ b/src/modules/home/modules/endorsements/property-quotator/components/MovementValues.vue
@@ -431,22 +431,22 @@ export default {
         case 1: // Original currency action
           switch (concept) {
             case "damage":
-              this.movementValuesComputed[1].damage = Decimal(
-                !value ? 0 : Decimal(value)
-              ).div(Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].damage = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
 
             case "bi":
-              this.movementValuesComputed[1].bi = Decimal(
-                !value ? 0 : Decimal(value)
-              ).div(Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].bi = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
 
             case "stocks":
-              this.movementValuesComputed[1].stocks = Decimal(
-                !value ? 0 : Decimal(value)
-              ).div(Decimal(this.exchangeRate || 0));
-              return value;
+              this.movementValuesComputed[1].stocks = Decimal(value || 0)
+                .div(Decimal(this.exchangeRate || 1))
+                .toNumber();
+              return Number(value) || 0;
           }
         case 2: // USD action
           return 29;


### PR DESCRIPTION
## Summary
- ensure movement value components pass numeric values to currency inputs
- validate net premium calculations across endorsement forms
- replace deprecated tooltip directive with native title

## Testing
- `npm run test:unit`
- `npm install --no-audit --no-fund` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68b074b9d090832c9169999e878d0a38